### PR TITLE
Change stride indexing for MaxPool loss statistics

### DIFF
--- a/streaming/torch_utils/scnn.py
+++ b/streaming/torch_utils/scnn.py
@@ -924,8 +924,8 @@ class StreamingCNN(object):
                 f_grad = torch.sum(grad_out[0], dim=1)[0]
                 f_grad = f_grad * new_outpt
                 f_grad = f_grad.cpu()
-                f_grad = np.repeat(f_grad, stride[0], axis=0)
-                f_grad = np.repeat(f_grad, stride[1], axis=1)
+                f_grad = np.repeat(f_grad, stride[1], axis=0)
+                f_grad = np.repeat(f_grad, stride[2], axis=1)
                 grad = np.zeros(grad_in[0].shape[2:])
                 grad[:f_grad.shape[0], :f_grad.shape[1]] = f_grad
                 f_grad = torch.from_numpy(grad)


### PR DESCRIPTION
Fixed the strides when computing loss statistics for MaxPool2D when repeating the Tensor for average pool gradients

Calling for maxpool stride kernels in

        stride, kernel_size, _ = _triple(module.stride), _triple(module.kernel_size), _triple(module.padding)
yields a tuple of 3 elements instead of 2, depending on how the MaxPool2D is defined. It can give back a wrong stride size when calling stride[0]. Instead, stride[1] and stride[2] must be called

Example below:
MaxPool((8,8), stride=(8,8)) -> yields stride (0,8,8) Maxpool((8,8)) -> yields stride (0,8,8)
MaxPool(8) -> yields stride (0,8,8)